### PR TITLE
fix: wait for page loaded

### DIFF
--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -25,7 +25,9 @@ export function navigateToCanvas(browser: Browser, path?: string): Promise<Page>
 
 export async function navigateInNewPage(browser: Browser, url: string): Promise<Page> {
   const page = await browser.newPage();
-  await page.goto(url);
+  await page.goto(url, {
+    waitUntil: 'domcontentloaded',
+  });
   await page.bringToFront();
 
   return page;


### PR DESCRIPTION
I was starting to scrape before page actually finished loading! This 
made scraping to fail in weird moments like:
- Incomplete texts.
- Corrupted picture.