### PR TITLE
feat: configurable wait until

### DIFF
--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -3,7 +3,7 @@
 //   TPage as Page,
 //   TElementHandle as ElementHandle,
 // } from 'foxr';
-import puppeteer, { Browser, Page, ElementHandle } from 'puppeteer';
+import puppeteer, { Browser, Page, ElementHandle, NavigationOptions } from 'puppeteer';
 // import uuidv4 from 'uuid/v4';
 import getConfig from './config';
 
@@ -23,10 +23,14 @@ export function navigateToCanvas(browser: Browser, path?: string): Promise<Page>
   return navigateInNewPage(browser, `${getConfig().canvasHost}${path}`);
 }
 
-export async function navigateInNewPage(browser: Browser, url: string): Promise<Page> {
+export async function navigateInNewPage(
+  browser: Browser,
+  url: string,
+  waitUntil: NavigationOptions['waitUntil'] = 'domcontentloaded'
+): Promise<Page> {
   const page = await browser.newPage();
   await page.goto(url, {
-    waitUntil: 'networkidle0',
+    waitUntil,
   });
   await page.bringToFront();
 

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -167,7 +167,7 @@ export async function downloadImage(
   picPath: string
 ): Promise<void> {
   // We need to go to a new tab our it throws a navigation error.
-  const imagePage = await navigateInNewPage(browser, picUrl);
+  const imagePage = await navigateInNewPage(browser, picUrl, 'networkidle0');
   const source = await imagePage.goto(picUrl);
   if (!source) {
     throw new ImageNotFound(picUrl);


### PR DESCRIPTION
To load a page, we need `domcontentloaded` but for images, we need to 
wait for network to be done.

If we only use `domcontentload` then some pictures won't load correctly.

And if we use 'networkidle0' then when the dom is too big it won't load 
on time after network gets idle.